### PR TITLE
Simplified interface in modeler

### DIFF
--- a/App/javasource/xpath/actions/RetrieveByXpath.java
+++ b/App/javasource/xpath/actions/RetrieveByXpath.java
@@ -17,33 +17,25 @@ import java.util.List;
 
 public class RetrieveByXpath extends CustomJavaAction<java.util.List<IMendixObject>>
 {
-	private IMendixObject ReturnObjectType;
+	private java.lang.String ReturnObjectType;
 	private IMendixObject __Xpath;
 	private xpath.proxies.Xpath Xpath;
 	private java.lang.Long Amount;
 	private java.lang.Long Offset;
-	private java.util.List<IMendixObject> __Sort;
-	private java.util.List<xpath.proxies.SortMap> Sort;
 
-	public RetrieveByXpath(IContext context, IMendixObject ReturnObjectType, IMendixObject Xpath, java.lang.Long Amount, java.lang.Long Offset, java.util.List<IMendixObject> Sort)
+	public RetrieveByXpath(IContext context, java.lang.String ReturnObjectType, IMendixObject Xpath, java.lang.Long Amount, java.lang.Long Offset)
 	{
 		super(context);
 		this.ReturnObjectType = ReturnObjectType;
 		this.__Xpath = Xpath;
 		this.Amount = Amount;
 		this.Offset = Offset;
-		this.__Sort = Sort;
 	}
 
 	@java.lang.Override
 	public java.util.List<IMendixObject> executeAction() throws Exception
 	{
-		this.Xpath = __Xpath == null ? null : xpath.proxies.Xpath.initialize(getContext(), __Xpath);
-
-		this.Sort = new java.util.ArrayList<xpath.proxies.SortMap>();
-		if (__Sort != null)
-			for (IMendixObject __SortElement : __Sort)
-				this.Sort.add(xpath.proxies.SortMap.initialize(getContext(), __SortElement));
+		this.Xpath = this.__Xpath == null ? null : xpath.proxies.Xpath.initialize(getContext(), __Xpath);
 
 		// BEGIN USER CODE
 
@@ -58,7 +50,7 @@ public class RetrieveByXpath extends CustomJavaAction<java.util.List<IMendixObje
 			offset = 0;
 		}
 
-		List<IMendixObject> result = xpathHelper.retrieveByXpath(getContext(), amount, offset, Sort, ReturnObjectType, Xpath);
+		List<IMendixObject> result = xpathHelper.retrieveByXpath(getContext(), amount, offset, ReturnObjectType, Xpath);
 		return result == null ? null : result;
 
 		// END USER CODE
@@ -66,6 +58,7 @@ public class RetrieveByXpath extends CustomJavaAction<java.util.List<IMendixObje
 
 	/**
 	 * Returns a string representation of this action
+	 * @return a string representation of this action
 	 */
 	@java.lang.Override
 	public java.lang.String toString()

--- a/App/javasource/xpath/actions/RetrieveByXpathAggregate_Decimal.java
+++ b/App/javasource/xpath/actions/RetrieveByXpathAggregate_Decimal.java
@@ -9,29 +9,21 @@
 
 package xpath.actions;
 
-import com.mendix.core.Core;
 import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 import com.mendix.systemwideinterfaces.core.IMendixObject;
 import xpath.helper.xpathHelper;
-import xpath.proxies.AggregateType;
-import xpath.proxies.SortMap;
 import java.math.BigDecimal;
-import java.math.MathContext;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Logger;
-import static com.mendix.core.Core.*;
 
 public class RetrieveByXpathAggregate_Decimal extends CustomJavaAction<java.math.BigDecimal>
 {
-	private IMendixObject ReturnObjectType;
+	private java.lang.String ReturnObjectType;
 	private IMendixObject __Xpath;
 	private xpath.proxies.Xpath Xpath;
 	private xpath.proxies.AggregateType AggregateType;
 	private java.lang.String attributeName;
 
-	public RetrieveByXpathAggregate_Decimal(IContext context, IMendixObject ReturnObjectType, IMendixObject Xpath, java.lang.String AggregateType, java.lang.String attributeName)
+	public RetrieveByXpathAggregate_Decimal(IContext context, java.lang.String ReturnObjectType, IMendixObject Xpath, java.lang.String AggregateType, java.lang.String attributeName)
 	{
 		super(context);
 		this.ReturnObjectType = ReturnObjectType;
@@ -43,7 +35,7 @@ public class RetrieveByXpathAggregate_Decimal extends CustomJavaAction<java.math
 	@java.lang.Override
 	public java.math.BigDecimal executeAction() throws Exception
 	{
-		this.Xpath = __Xpath == null ? null : xpath.proxies.Xpath.initialize(getContext(), __Xpath);
+		this.Xpath = this.__Xpath == null ? null : xpath.proxies.Xpath.initialize(getContext(), __Xpath);
 
 		// BEGIN USER CODE
 
@@ -55,6 +47,7 @@ public class RetrieveByXpathAggregate_Decimal extends CustomJavaAction<java.math
 
 	/**
 	 * Returns a string representation of this action
+	 * @return a string representation of this action
 	 */
 	@java.lang.Override
 	public java.lang.String toString()

--- a/App/javasource/xpath/actions/RetrieveByXpathAggregate_Int.java
+++ b/App/javasource/xpath/actions/RetrieveByXpathAggregate_Int.java
@@ -9,29 +9,20 @@
 
 package xpath.actions;
 
-import com.mendix.core.Core;
 import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 import com.mendix.systemwideinterfaces.core.IMendixObject;
 import xpath.helper.xpathHelper;
-import xpath.proxies.AggregateType;
-import xpath.proxies.SortMap;
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Logger;
-import static com.mendix.core.Core.*;
 
 public class RetrieveByXpathAggregate_Int extends CustomJavaAction<java.lang.Long>
 {
-	private IMendixObject ReturnObjectType;
+	private java.lang.String ReturnObjectType;
 	private IMendixObject __Xpath;
 	private xpath.proxies.Xpath Xpath;
 	private xpath.proxies.AggregateType AggregateType;
 	private java.lang.String attributeName;
 
-	public RetrieveByXpathAggregate_Int(IContext context, IMendixObject ReturnObjectType, IMendixObject Xpath, java.lang.String AggregateType, java.lang.String attributeName)
+	public RetrieveByXpathAggregate_Int(IContext context, java.lang.String ReturnObjectType, IMendixObject Xpath, java.lang.String AggregateType, java.lang.String attributeName)
 	{
 		super(context);
 		this.ReturnObjectType = ReturnObjectType;
@@ -43,7 +34,7 @@ public class RetrieveByXpathAggregate_Int extends CustomJavaAction<java.lang.Lon
 	@java.lang.Override
 	public java.lang.Long executeAction() throws Exception
 	{
-		this.Xpath = __Xpath == null ? null : xpath.proxies.Xpath.initialize(getContext(), __Xpath);
+		this.Xpath = this.__Xpath == null ? null : xpath.proxies.Xpath.initialize(getContext(), __Xpath);
 
 		// BEGIN USER CODE
 		Long result = xpathHelper.retrieveByXpathAggregate(getContext(), Xpath, AggregateType, attributeName, ReturnObjectType);
@@ -53,6 +44,7 @@ public class RetrieveByXpathAggregate_Int extends CustomJavaAction<java.lang.Lon
 
 	/**
 	 * Returns a string representation of this action
+	 * @return a string representation of this action
 	 */
 	@java.lang.Override
 	public java.lang.String toString()

--- a/App/javasource/xpath/helper/xpathHelper.java
+++ b/App/javasource/xpath/helper/xpathHelper.java
@@ -1,5 +1,6 @@
 package xpath.helper;
 
+import com.mendix.core.Core;
 import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.systemwideinterfaces.core.IMendixObject;
 import xpath.proxies.AggregateType;
@@ -16,7 +17,7 @@ import static com.mendix.core.Core.retrieveXPathQueryAggregateDouble;
 
 public class xpathHelper {
 
-    public static List<IMendixObject> retrieveByXpath (IContext context, int Amount, int Offset, java.util.List<xpath.proxies.SortMap> Sort, IMendixObject ReturnObjectType, xpath.proxies.Xpath xpathObj) throws Exception  {
+    public static List<IMendixObject> retrieveByXpath (IContext context, int Amount, int Offset, String ReturnObjectType, xpath.proxies.Xpath xpathObj) throws Exception  {
 
 
         if (xpathObj == null){
@@ -28,9 +29,10 @@ public class xpathHelper {
 
 
         Map<String,String> sortMap = new HashMap<String, String>();
-
-        for ( SortMap sort : Sort){
-            Boolean sortAscending = sort.getSortAscending();
+        
+        for ( IMendixObject s : Core.retrieveByPath(context, xpathObj.getMendixObject(), SortMap.MemberNames.SortMap_Xpath.toString(), true)){
+            SortMap sort = SortMap.initialize(context, s);
+        	Boolean sortAscending = sort.getSortAscending();
 
             String sortDirection;
             if (sortAscending){
@@ -61,7 +63,7 @@ public class xpathHelper {
 
     }
 
-    public static BigDecimal retrieveByXpathAggregateDecimal (IContext context, xpath.proxies.Xpath xpathObj, xpath.proxies.AggregateType AggregateType, java.lang.String attributeName, IMendixObject ReturnObjectType) throws Exception  {
+    public static BigDecimal retrieveByXpathAggregateDecimal (IContext context, xpath.proxies.Xpath xpathObj, xpath.proxies.AggregateType AggregateType, java.lang.String attributeName, String ReturnObjectType) throws Exception  {
 
         String xpathQuery = getXpathAggregateQuery(ReturnObjectType, xpathObj, AggregateType,attributeName);
 
@@ -80,7 +82,7 @@ public class xpathHelper {
 
     }
 
-    public static Long retrieveByXpathAggregate (IContext context, xpath.proxies.Xpath xpathObj, xpath.proxies.AggregateType AggregateType, java.lang.String attributeName, IMendixObject ReturnObjectType) throws Exception  {
+    public static Long retrieveByXpathAggregate (IContext context, xpath.proxies.Xpath xpathObj, xpath.proxies.AggregateType AggregateType, java.lang.String attributeName, String ReturnObjectType) throws Exception  {
 
         String xpathQuery = getXpathAggregateQuery(ReturnObjectType, xpathObj, AggregateType,attributeName);
 
@@ -99,9 +101,9 @@ public class xpathHelper {
     }
 
 
-    public static String getXpath (IMendixObject ReturnObjectType, xpath.proxies.Xpath xpathObj) {
+    public static String getXpath (String ReturnObjectType, xpath.proxies.Xpath xpathObj) {
 
-        String xpathStart = "//" +  ReturnObjectType.getMetaObject().getName();
+        String xpathStart = "//" +  ReturnObjectType;
         String xpath;
 
         if (xpathObj.getQuery() == null){
@@ -116,7 +118,7 @@ public class xpathHelper {
         return xpath;
     }
 
-    public static String getXpathAggregateQuery (IMendixObject ReturnObjectType, xpath.proxies.Xpath xpathObj, xpath.proxies.AggregateType AggregateType, java.lang.String attributeName) {
+    public static String getXpathAggregateQuery (String ReturnObjectType, xpath.proxies.Xpath xpathObj, xpath.proxies.AggregateType AggregateType, java.lang.String attributeName) {
 
         String xpathQuery;
         String xpathConstraint = getXpath(ReturnObjectType, xpathObj);


### PR DESCRIPTION
Simplified the interface for the Java actions in the modeler by:
1. Passing the return entity as Entity and not an object (no need to create dummy object)
2. Retrieve sort objects via association with XPath object. So you don't have to pass the list